### PR TITLE
Add HTTPS option

### DIFF
--- a/src/config/ducky-api-config.class.ts
+++ b/src/config/ducky-api-config.class.ts
@@ -148,4 +148,12 @@ export class DuckyApiConfig {
   @IsNumber()
   @Min(0)
   DELAY: number
+
+  @IsNotEmpty()
+  @IsString()
+  TLS_KEY_PATH: string
+
+  @IsNotEmpty()
+  @IsString()
+  TLS_CERT_PATH: string
 }

--- a/src/config/ducky-api-config.class.ts
+++ b/src/config/ducky-api-config.class.ts
@@ -148,4 +148,14 @@ export class DuckyApiConfig {
   @IsNumber()
   @Min(0)
   DELAY: number
+  
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  TLS_KEY_PATH: string
+
+  @IsOptional()
+  @IsNotEmpty()
+  @IsString()
+  TLS_CERT_PATH: string
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import fs from 'fs'
 import Helmet from 'helmet'
 import { resolve } from 'path'
 import { promisify } from 'util'
+import { ExpressAdapter } from '@nestjs/platform-express'
+import * as express from 'express';
 
 import { AppModule } from './app.module'
 import { UnauthorizedExceptionFilter } from './common/filters/unauthorized-exception.filter'
@@ -15,23 +17,13 @@ const writeFile = promisify(fs.writeFile)
 declare const module: any
 
 async function bootstrap(): Promise<void> {
+  const server = express()
+  const app = await NestFactory.create(
+    AppModule,
+    new ExpressAdapter(server)
+  )
+
   const config: ConfigService = app.get('ConfigService')
-  let nestConfig: {
-    httpsOptions: {
-        key: string,
-        cert: string
-    }
-  }
-
-  const app = await NestFactory.create(AppModule, nestConfig);
-
-  if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
-    const fs = require('fs');
-    app.appOptions.httpsOptions = {
-        key: fs.readFileSync(config.TLS_KEY_PATH),
-        cert: fs.readFileSync(config.TLS_CERT_PATH)
-    };
-  }
 
   if (config.SERVE_DUCKYPANEL) {
     // Write baseurl to file for DuckyPanel to find
@@ -70,8 +62,19 @@ async function bootstrap(): Promise<void> {
       displayOperationId: true,
     },
   })
+  
+  await app.init()
 
-  await app.listen(config.PORT)
+  if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
+    const fs = require('fs')
+    await https.createServer({
+        key: fs.readFileSync(config.TLS_KEY_PATH),
+        cert: fs.readFileSync(config.TLS_CERT_PATH)
+    }, server).listen(config.PORT)
+  }
+  else {
+    await http.createServer(server).listen(config.PORT)
+  }
 
   if (module.hot) {
     module.hot.accept()

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,15 +23,15 @@ async function bootstrap(): Promise<void> {
     }
   }
 
+  const app = await NestFactory.create(AppModule, nestConfig);
+
   if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
     const fs = require('fs');
-    nestConfig.httpsOptions = {
+    app.appOptions.httpsOptions = {
         key: fs.readFileSync(config.TLS_KEY_PATH),
         cert: fs.readFileSync(config.TLS_CERT_PATH)
     };
   }
-
-  const app = await NestFactory.create(AppModule, nestConfig);
 
   if (config.SERVE_DUCKYPANEL) {
     // Write baseurl to file for DuckyPanel to find

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,8 +15,18 @@ const writeFile = promisify(fs.writeFile)
 declare const module: any
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule)
   const config: ConfigService = app.get('ConfigService')
+  let nestConfig = {}
+
+  if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
+    const fs = require('fs');
+    nestConfig.httpsOptions = {
+        key: fs.readFileSync(config.TLS_KEY_PATH),
+        cert: fs.readFileSync(config.TLS_CERT_PATH)
+    };
+  }
+
+  const app = await NestFactory.create(AppModule, nestConfig);
 
   if (config.SERVE_DUCKYPANEL) {
     // Write baseurl to file for DuckyPanel to find

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ async function bootstrap(): Promise<void> {
   await app.init()
 
   if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
+    const https = require('https')
     const fs = require('fs')
     await https.createServer({
         key: fs.readFileSync(config.TLS_KEY_PATH),
@@ -73,6 +74,7 @@ async function bootstrap(): Promise<void> {
     }, server).listen(config.PORT)
   }
   else {
+    const http = require('http')
     await http.createServer(server).listen(config.PORT)
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ const writeFile = promisify(fs.writeFile)
 declare const module: any
 
 async function bootstrap(): Promise<void> {
-  const server = express()
+  const server = express.default()
   const app = await NestFactory.create(
     AppModule,
     new ExpressAdapter(server)

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,12 @@ declare const module: any
 
 async function bootstrap(): Promise<void> {
   const config: ConfigService = app.get('ConfigService')
-  let nestConfig = {}
+  let nestConfig: {
+    httpsOptions: {
+        key: string,
+        cert: string
+    }
+  }
 
   if (config.TLS_KEY_PATH && config.TLS_CERT_PATH) {
     const fs = require('fs');


### PR DESCRIPTION
We're currently testing out DuckyAPI on Kubernetes and we have a practice of using HTTPS even in internal cluster communications. Others might find this helpful for different reasons.